### PR TITLE
Set BootVolumeSizeInGBs only when image size is not 0 and is valid

### DIFF
--- a/builder/oci/config.go
+++ b/builder/oci/config.go
@@ -380,9 +380,7 @@ func (c *Config) Prepare(raws ...interface{}) error {
 
 	// Set default boot volume size to 50 if not set
 	// Check if size set is allowed by OCI
-	if c.BootVolumeSizeInGBs == 0 {
-		c.BootVolumeSizeInGBs = 50
-	} else if c.BootVolumeSizeInGBs < 50 || c.BootVolumeSizeInGBs > 16384 {
+	if c.BootVolumeSizeInGBs != 0 && (c.BootVolumeSizeInGBs < 50 || c.BootVolumeSizeInGBs > 16384) {
 		errs = packersdk.MultiErrorAppend(
 			errs, errors.New("'disk_size' must be between 50 and 16384 GBs"))
 	}

--- a/builder/oci/driver_oci.go
+++ b/builder/oci/driver_oci.go
@@ -140,9 +140,10 @@ func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (strin
 	}
 
 	// Create Source details which will be used to Launch Instance
-	InstanceSourceDetails := core.InstanceSourceViaImageDetails{
-		ImageId:             imageId,
-		BootVolumeSizeInGBs: &d.cfg.BootVolumeSizeInGBs,
+	InstanceSourceDetails := core.InstanceSourceViaImageDetails{ImageId: imageId}
+
+	if d.cfg.BootVolumeSizeInGBs != 0 {
+		InstanceSourceDetails.BootVolumeSizeInGBs = &d.cfg.BootVolumeSizeInGBs
 	}
 
 	// Build instance details


### PR DESCRIPTION
Opened for @harveylowndes since we extracted the oracle plugin out from under his PR. 

supercedes https://github.com/hashicorp/packer/pull/10849

closes https://github.com/hashicorp/packer/issues/10399