### PR TITLE
Fix: Persist generated private key to communicator config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.2 (Unreleased)
+
+* Fix: Persist generated private key to `StepKeyPair` communicator config.
+
 ## 1.0.1 (August 25, 2021)
 
 * Added support for [token-based authentication](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm)

--- a/builder/common/step_ssh_key_pair.go
+++ b/builder/common/step_ssh_key_pair.go
@@ -75,6 +75,7 @@ func (s *StepKeyPair) Run(ctx context.Context, state multistep.StateBag) multist
 	}
 
 	s.Comm.SSHPublicKey = ssh.MarshalAuthorizedKey(pub)
+	s.Comm.SSHPrivateKey = pem.EncodeToMemory(&privBlk)
 
 	// If we're in debug mode, output the private key to the working
 	// directory.

--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.0.1"
+	Version = "1.0.2"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
Change to save the generated private key contents back to the communicator configuration. This allows other provisioners to connect to the instance.

Closes #41

