### PR TITLE
Remove Solaris as supported distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,12 +58,6 @@ jobs:
     steps:
       - build-and-persist-plugin-binary:
           GOOS: freebsd
-  build_solaris:
-    executor: golang
-    working_directory: ~/go/src/github.com/hashicorp/packer-plugin-oracle
-    steps:
-      - build-and-persist-plugin-binary:
-          GOOS: solaris
   build_openbsd:
     executor: golang
     working_directory: ~/go/src/github.com/hashicorp/packer-plugin-oracle
@@ -89,7 +83,6 @@ workflows:
       - build_windows
       - build_freebsd
       - build_openbsd
-      - build_solaris
       - store_artifacts:
           requires:
             - build_linux
@@ -98,4 +91,3 @@ workflows:
             - build_windows
             - build_freebsd
             - build_openbsd
-            - build_solaris

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,38 @@ builds:
       - amd64
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
   -
+    id: linux-builds
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath #removes all file system paths from the compiled executable
+    ldflags:
+      - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: linux
+        goarch: amd64
+    binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
+  -
+    id: darwin-builds
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath #removes all file system paths from the compiled executable
+    ldflags:
+      - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
+  -
+    id: other-builds
     mod_timestamp: '{{ .CommitTimestamp }}'
     flags:
       - -trimpath #removes all file system paths from the compiled executable
@@ -34,24 +66,21 @@ builds:
       - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
     goos:
       - netbsd
-      - solaris
       - openbsd
       - freebsd
       - windows
-      - linux
-      - darwin
+      - solaris
     goarch:
       - amd64
       - '386'
       - arm
-      - arm64
     ignore:
-      - goos: openbsd
-        goarch: arm64
-      - goos: darwin
+      - goos: windows
+        goarch: arm
+      - goos: solaris
+        goarch: arm
+      - goos: solaris
         goarch: '386'
-      - goos: linux
-        goarch: amd64
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 archives:
 - format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,7 +69,6 @@ builds:
       - openbsd
       - freebsd
       - windows
-      - solaris
     goarch:
       - amd64
       - '386'
@@ -77,10 +76,6 @@ builds:
     ignore:
       - goos: windows
         goarch: arm
-      - goos: solaris
-        goarch: arm
-      - goos: solaris
-        goarch: '386'
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 archives:
 - format: zip


### PR DESCRIPTION
This change ultimately removes support for Solaris as a supported distribution. 

As mentioned in pull-request https://github.com/hashicorp/packer-plugin-oracle/pull/48 support for Solaris was dropped by the OCI SDK team in order to support eventual consistency work in the Terraform provider. Currently, the Packer plugin build for Solaris is failing because the gofrs Go package does not support Solaris. Since this plugin is maintained by the community and the OCI SDK team does not support Solaris support is being dropped from this plugin, as well.

After the next release the Oracle plugin will no longer be bundled with Packer as an embedded plugin, which does have support for Solaris. 


**Additional changes made in this PR:**

* Update Plugin binary releases to match Packer

The goreleaser binary release matrix has been updated to match the binaries platforms distributed by Packer core. A complete list of supported binaries can be found at https://releases.hashicorp.com/packer/1.8.3

Example of binaries to be released
```
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_darwin_amd64.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_darwin_arm64.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_freebsd_386.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_freebsd_amd64.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_freebsd_arm.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_linux_386.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_linux_amd64.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_linux_arm.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_linux_arm64.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_netbsd_386.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_netbsd_amd64.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_netbsd_arm.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_openbsd_386.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_openbsd_amd64.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_openbsd_arm.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_windows_386.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_5.0_windows_amd64.zip
packer-plugin-oracle_v1.0.2-SNAPSHOT-75d8a94_SHA256SUMS
```