### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/docs/builders/classic.mdx
+++ b/docs/builders/classic.mdx
@@ -137,7 +137,7 @@ to Object Storage Classic, and create a new machine image with it.
 If this is set, a few more options become available.
 
 - `builder_communicator` (communicator) - This represents an
-  [`ssh communicator`](/docs/communicators/ssh),
+  [`ssh communicator`](/packer/docs/communicators/ssh),
   and can be configured as such. If you use a different builder image, you
   may need to change the `ssh_username`, for example. That might look like
   this:

--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -10,11 +10,11 @@ Packer is able to create custom images on both Oracle Cloud Infrastructure and
 Oracle Cloud Infrastructure Classic Compute. Packer comes with builders
 designed to support both platforms. Please choose the one that's right for you:
 
-- [oracle-classic](./classic) - Create custom images
+- [oracle-classic](/packer/plugins/builders/oracle/classic) - Create custom images
   in Oracle Cloud Infrastructure Classic Compute by launching a source
   instance and creating an image list from a snapshot of it after
   provisioning.
 
-- [oracle-oci](./oci) - Create custom images in
+- [oracle-oci](/packer/plugins/builders/oracle/oci) - Create custom images in
   Oracle Cloud Infrastructure (OCI) by launching a base instance and creating
   an image from it after provisioning.

--- a/docs/builders/oci.mdx
+++ b/docs/builders/oci.mdx
@@ -79,7 +79,7 @@ used as a reference for this method.
 
 There are many configuration options available for the `oracle-oci` builder. In
 addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder.
 
 In addition to the options defined there, a private key file
@@ -148,8 +148,8 @@ can also be supplied to override the typical auto-generated key:
   operation available in the Core Services API.
 
   Note: the subnet must be configured to allow access via your chosen
-  [communicator](/docs/communicators) (communicator defaults to
-  [SSH tcp/22](/docs/communicators/ssh#ssh_port)).
+  [communicator](/packer/docs/communicators) (communicator defaults to
+  [SSH tcp/22](/packer/docs/communicators/ssh#ssh_port)).
 
 
 ### Authentication parameters


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them