### PR TITLE
Support setting baseline_ocpu_utilization to allow burstable instances to be launched

### DIFF
--- a/builder/oci/config.go
+++ b/builder/oci/config.go
@@ -53,8 +53,9 @@ type ListImagesRequest struct {
 }
 
 type FlexShapeConfig struct {
-	Ocpus       *float32 `mapstructure:"ocpus" required:"false"`
-	MemoryInGBs *float32 `mapstructure:"memory_in_gbs" required:"false"`
+	Ocpus                   *float32 `mapstructure:"ocpus" required:"false"`
+	MemoryInGBs             *float32 `mapstructure:"memory_in_gbs" required:"false"`
+	BaselineOcpuUtilization *string  `mapstructure:"baseline_ocpu_utilization" required:"false"`
 }
 
 type Config struct {
@@ -337,6 +338,11 @@ func (c *Config) Prepare(raws ...interface{}) error {
 	if c.ShapeConfig.MemoryInGBs != nil && c.ShapeConfig.Ocpus == nil {
 		errs = packersdk.MultiErrorAppend(
 			errs, errors.New("'Ocpus' must be specified if memory_in_gbs is specified"))
+	}
+
+	if c.ShapeConfig.BaselineOcpuUtilization != nil && c.ShapeConfig.Ocpus == nil {
+		errs = packersdk.MultiErrorAppend(
+			errs, errors.New("'Ocpus' must be specified if baseline_ocpu_utilization is specified"))
 	}
 
 	if (c.SubnetID == "") && (c.CreateVnicDetails.SubnetId == nil) {

--- a/builder/oci/config.hcl2spec.go
+++ b/builder/oci/config.hcl2spec.go
@@ -250,8 +250,9 @@ func (*FlatCreateVNICDetails) HCL2Spec() map[string]hcldec.Spec {
 // FlatFlexShapeConfig is an auto-generated flat version of FlexShapeConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatFlexShapeConfig struct {
-	Ocpus       *float32 `mapstructure:"ocpus" required:"false" cty:"ocpus" hcl:"ocpus"`
-	MemoryInGBs *float32 `mapstructure:"memory_in_gbs" required:"false" cty:"memory_in_gbs" hcl:"memory_in_gbs"`
+	Ocpus                   *float32 `mapstructure:"ocpus" required:"false" cty:"ocpus" hcl:"ocpus"`
+	MemoryInGBs             *float32 `mapstructure:"memory_in_gbs" required:"false" cty:"memory_in_gbs" hcl:"memory_in_gbs"`
+	BaselineOcpuUtilization *string  `mapstructure:"baseline_ocpu_utilization" required:"false" cty:"baseline_ocpu_utilization" hcl:"baseline_ocpu_utilization"`
 }
 
 // FlatMapstructure returns a new FlatFlexShapeConfig.
@@ -266,8 +267,9 @@ func (*FlexShapeConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcld
 // The decoded values from this spec will then be applied to a FlatFlexShapeConfig.
 func (*FlatFlexShapeConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"ocpus":         &hcldec.AttrSpec{Name: "ocpus", Type: cty.Number, Required: false},
-		"memory_in_gbs": &hcldec.AttrSpec{Name: "memory_in_gbs", Type: cty.Number, Required: false},
+		"ocpus":                     &hcldec.AttrSpec{Name: "ocpus", Type: cty.Number, Required: false},
+		"memory_in_gbs":             &hcldec.AttrSpec{Name: "memory_in_gbs", Type: cty.Number, Required: false},
+		"baseline_ocpu_utilization": &hcldec.AttrSpec{Name: "baseline_ocpu_utilization", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/oci/driver_oci.go
+++ b/builder/oci/driver_oci.go
@@ -160,8 +160,9 @@ func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (strin
 
 	if d.cfg.ShapeConfig.Ocpus != nil {
 		LaunchInstanceShapeConfigDetails := core.LaunchInstanceShapeConfigDetails{
-			Ocpus:       d.cfg.ShapeConfig.Ocpus,
-			MemoryInGBs: d.cfg.ShapeConfig.MemoryInGBs,
+			Ocpus:                   d.cfg.ShapeConfig.Ocpus,
+			MemoryInGBs:             d.cfg.ShapeConfig.MemoryInGBs,
+			BaselineOcpuUtilization: core.LaunchInstanceShapeConfigDetailsBaselineOcpuUtilizationEnum(*d.cfg.ShapeConfig.BaselineOcpuUtilization),
 		}
 		instanceDetails.ShapeConfig = &LaunchInstanceShapeConfigDetails
 	}

--- a/builder/oci/driver_oci.go
+++ b/builder/oci/driver_oci.go
@@ -160,10 +160,14 @@ func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (strin
 
 	if d.cfg.ShapeConfig.Ocpus != nil {
 		LaunchInstanceShapeConfigDetails := core.LaunchInstanceShapeConfigDetails{
-			Ocpus:                   d.cfg.ShapeConfig.Ocpus,
-			MemoryInGBs:             d.cfg.ShapeConfig.MemoryInGBs,
-			BaselineOcpuUtilization: core.LaunchInstanceShapeConfigDetailsBaselineOcpuUtilizationEnum(*d.cfg.ShapeConfig.BaselineOcpuUtilization),
+			Ocpus:       d.cfg.ShapeConfig.Ocpus,
+			MemoryInGBs: d.cfg.ShapeConfig.MemoryInGBs,
 		}
+
+		if d.cfg.ShapeConfig.BaselineOcpuUtilization != nil {
+			LaunchInstanceShapeConfigDetails.BaselineOcpuUtilization = core.LaunchInstanceShapeConfigDetailsBaselineOcpuUtilizationEnum(*d.cfg.ShapeConfig.BaselineOcpuUtilization)
+		}
+
 		instanceDetails.ShapeConfig = &LaunchInstanceShapeConfigDetails
 	}
 

--- a/docs/builders/oci.mdx
+++ b/docs/builders/oci.mdx
@@ -265,6 +265,8 @@ or configured for the default OCI CLI authenticaton profile.
   allocated to an instance. Options:
   - `ocpus` (required when using flexible shapes or memory_in_gbs is set) (float32) - The total number of OCPUs available to the instance.
   - `memory_in_gbs` (optional) (float32) - The total amount of memory, in gigabytes, available to the instance.
+  - `baseline_ocpu_utilization` (optional) (string) - The baseline OCPU utilization for a burstable instance.
+    Valid values are `"BASELINE_1_8"`, `"BASELINE_1_2"`and `"BASELINE_1_1"`.
 
 <!-- markdown-link-check-disable -->
 


### PR DESCRIPTION
This change adds the `shape_config.baseline_ocpu_utilization` parameter so that flexible instances can be customized to be burstable.

Closes #74