### PR TITLE
Add support for HCP Packer

### DIFF
--- a/builder/classic/builder.go
+++ b/builder/classic/builder.go
@@ -194,6 +194,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 	// Build the artifact and return it
 	artifact := &Artifact{
+		APIEndpoint:      b.config.APIEndpoint,
+		SourceImageList:  b.config.SourceImageList,
 		ImageListVersion: state.Get("image_list_version").(int),
 		MachineImageName: state.Get("machine_image_name").(string),
 		MachineImageFile: state.Get("machine_image_file").(string),


### PR DESCRIPTION
This change adds support for sending metadata to HCP Packer.

Successfully tested with my HCP Packer registry:
![screenshot](https://user-images.githubusercontent.com/2263040/209909293-bd25dbbe-a630-48ac-8dcd-4ffbb655ff79.png)

Closes #75