### PR TITLE
.gitignore: ignore .docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/*
 packer-plugin-oracle
 .vscode/launch.json
 .vscode/settings.json
+.docs


### PR DESCRIPTION
The .docs directory is generated, and should therefore not be tracked by Git.