### PR TITLE
bump go 1.18 to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/packer-plugin-oracle
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-ini/ini v1.62.0


### PR DESCRIPTION
- Upgrade for new Integrations Library
- set as hcp ready
- docs: declutter README
- web-docs: rename builders for preview
- Adds release check & update Makefile command
- Convert tab titles to bolded
- docs: add installation instructions to README
- docs: fix oracle required_plugins block
- docs: fix initialization/init section
- go.mod: bump go version from 1.18 to 1.19
