### PR TITLE
add check and correction for null image capability schema

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -60,7 +60,7 @@ The following represent minimal required policies for the plugin to operate:
 Allow group PackerGroup to manage instance-family in compartment ${COMPARTMENT_NAME}
 Allow group PackerGroup to manage instance-images in compartment ${COMPARTMENT_NAME}
 Allow group PackerGroup to use virtual-network-family in compartment ${COMPARTMENT_NAME}
-Allow group PackerGroup to use compute-image-capability-schema in tenancy
+Allow group PackerGroup to manage compute-image-capability-schema in tenancy
 ```
 
 This example assumes the user running Packer is in a group named 'PackerGroup'.  You will need to update ${COMPARTMENT_NAME} to the name of the

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ The following represent minimal required policies for the plugin to operate:
 Allow group PackerGroup to manage instance-family in compartment ${COMPARTMENT_NAME}
 Allow group PackerGroup to manage instance-images in compartment ${COMPARTMENT_NAME}
 Allow group PackerGroup to use virtual-network-family in compartment ${COMPARTMENT_NAME}
-Allow group PackerGroup to use compute-image-capability-schema in tenancy
+Allow group PackerGroup to manage compute-image-capability-schema in tenancy
 ```
 
 This example assumes the user running Packer is in a group named 'PackerGroup'.  You will need to update ${COMPARTMENT_NAME} to the name of the


### PR DESCRIPTION
Some custom images may not have image capabilities schemas and this causes an array index error in the code as reported in Issue #86.  Update the UpdateImageCapabilitySchema() function to detect this condition and remediate by creating a schema based on the global schema and attaching to the instance before attempting to update.

Closes #86 

