### PR TITLE
spelling error

### DIFF
--- a/builder/oci/config.go
+++ b/builder/oci/config.go
@@ -220,7 +220,7 @@ func (c *Config) Prepare(raws ...interface{}) error {
 		// is assigned to c.configProvider otherwise testing fails because Instance
 		// Principals cannot be obtained.
 		if c.configProvider == nil {
-			// Even though the previous configuraion checks might fail we don't want
+			// Even though the previous configuration checks might fail we don't want
 			// to skip this step. It seems that the logic behind the checks in this
 			// file is to check everything even getting the configProvider.
 			c.configProvider, err = ociauth.InstancePrincipalConfigurationProvider()


### PR DESCRIPTION
The word `configuration` has been spelled `configuraion`, and in the eyes of one of my illustrious co-workers (Umar Dar) this is a firm tarnishing of the fine work that goes on here and shall not go unresolved in life.