### PR TITLE
Support passing API Signing Key from the memory

### DIFF
--- a/builder/oci/config.go
+++ b/builder/oci/config.go
@@ -193,28 +193,28 @@ func (c *Config) Prepare(raws ...interface{}) error {
 		// key involved.
 		var message string = " cannot be present when use_instance_principals is set to true."
 		if c.AccessCfgFile != "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("access_cfg_file"+message))
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("'access_cfg_file'"+message))
 		}
 		if c.AccessCfgFileAccount != "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("access_cfg_file_account"+message))
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("'access_cfg_file_account'"+message))
 		}
 		if c.UserID != "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("user_ocid"+message))
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("'user_ocid'"+message))
 		}
 		if c.TenancyID != "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("tenancy_ocid"+message))
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("'tenancy_ocid'"+message))
 		}
 		if c.Region != "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("region"+message))
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("'region'"+message))
 		}
 		if c.Fingerprint != "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("fingerprint"+message))
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("'fingerprint'"+message))
 		}
 		if c.KeyFile != "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("key_file"+message))
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("'key_file'"+message))
 		}
 		if c.PassPhrase != "" {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("pass_phrase"+message))
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("'pass_phrase'"+message))
 		}
 		// This check is used to facilitate testing. During testing a Mock struct
 		// is assigned to c.configProvider otherwise testing fails because Instance

--- a/builder/oci/config.go
+++ b/builder/oci/config.go
@@ -214,6 +214,9 @@ func (c *Config) Prepare(raws ...interface{}) error {
 		if c.KeyFile != "" {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("'key_file'"+message))
 		}
+		if c.Key != "" {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("'key'"+message))
+		}
 		if c.PassPhrase != "" {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("'pass_phrase'"+message))
 		}

--- a/builder/oci/config.go
+++ b/builder/oci/config.go
@@ -249,6 +249,7 @@ func (c *Config) Prepare(raws ...interface{}) error {
 			c.AccessCfgFileAccount = "DEFAULT"
 		}
 
+		// Read API signing key
 		var keyContent []byte
 		if c.KeyFile != "" {
 			path, err := pathing.ExpandUser(c.KeyFile)
@@ -266,6 +267,7 @@ func (c *Config) Prepare(raws ...interface{}) error {
 			keyContent = []byte(c.Key)
 		}
 
+		// Providers
 		fileProvider, _ := ocicommon.ConfigurationProviderFromFileWithProfile(c.AccessCfgFile, c.AccessCfgFileAccount, c.PassPhrase)
 		if c.Region == "" {
 			var region string

--- a/builder/oci/config.go
+++ b/builder/oci/config.go
@@ -92,6 +92,7 @@ type Config struct {
 	Region       string `mapstructure:"region"`
 	Fingerprint  string `mapstructure:"fingerprint"`
 	KeyFile      string `mapstructure:"key_file"`
+	Key          string `mapstructure:"key"`
 	PassPhrase   string `mapstructure:"pass_phrase"`
 	UsePrivateIP bool   `mapstructure:"use_private_ip"`
 
@@ -257,6 +258,9 @@ func (c *Config) Prepare(raws ...interface{}) error {
 			if err != nil {
 				return err
 			}
+		}
+		if c.Key != "" {
+			keyContent = []byte(c.Key)
 		}
 
 		fileProvider, _ := ocicommon.ConfigurationProviderFromFileWithProfile(c.AccessCfgFile, c.AccessCfgFileAccount, c.PassPhrase)

--- a/builder/oci/config.hcl2spec.go
+++ b/builder/oci/config.hcl2spec.go
@@ -76,6 +76,7 @@ type FlatConfig struct {
 	Region                    *string                `mapstructure:"region" cty:"region" hcl:"region"`
 	Fingerprint               *string                `mapstructure:"fingerprint" cty:"fingerprint" hcl:"fingerprint"`
 	KeyFile                   *string                `mapstructure:"key_file" cty:"key_file" hcl:"key_file"`
+	Key                       *string                `mapstructure:"key" cty:"key" hcl:"key"`
 	PassPhrase                *string                `mapstructure:"pass_phrase" cty:"pass_phrase" hcl:"pass_phrase"`
 	UsePrivateIP              *bool                  `mapstructure:"use_private_ip" cty:"use_private_ip" hcl:"use_private_ip"`
 	SecurityTokenFilePath     *string                `mapstructure:"security_token_file" cty:"security_token_file" hcl:"security_token_file"`
@@ -180,6 +181,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"region":                       &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"fingerprint":                  &hcldec.AttrSpec{Name: "fingerprint", Type: cty.String, Required: false},
 		"key_file":                     &hcldec.AttrSpec{Name: "key_file", Type: cty.String, Required: false},
+		"key":                          &hcldec.AttrSpec{Name: "key", Type: cty.String, Required: false},
 		"pass_phrase":                  &hcldec.AttrSpec{Name: "pass_phrase", Type: cty.String, Required: false},
 		"use_private_ip":               &hcldec.AttrSpec{Name: "use_private_ip", Type: cty.Bool, Required: false},
 		"security_token_file":          &hcldec.AttrSpec{Name: "security_token_file", Type: cty.String, Required: false},

--- a/builder/oci/config_test.go
+++ b/builder/oci/config_test.go
@@ -398,6 +398,7 @@ func TestConfig(t *testing.T) {
 		"tenancy_ocid",
 		"region",
 		"fingerprint",
+		"key",
 		"key_file",
 		"pass_phrase",
 	}

--- a/docs/builders/oci.mdx
+++ b/docs/builders/oci.mdx
@@ -108,7 +108,7 @@ based on which authentication method is used.
 - `use_instance_principals` (boolean) - Whether to use [Instance
   Principals](https://docs.cloud.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm)
   instead of User Principals. If this key is set to true, setting any one of the `access_cfg_file`,
-  `access_cfg_file_account`, `region`, `tenancy_ocid`, `user_ocid`, `key_file`, `fingerprint`,
+  `access_cfg_file_account`, `region`, `tenancy_ocid`, `user_ocid`, `key`, `key_file`, `fingerprint`,
   `pass_phrase` parameters will cause an invalid configuration error.
   Defaults to `false`.
 
@@ -141,6 +141,9 @@ or configured for the default OCI CLI authenticaton profile.
 - `user_ocid` (string) - The OCID of the user calling the OCI API. Overrides value provided by the
   [OCI config file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
   if present. This cannot be used along with the `use_instance_principals` key.
+
+- `key` (string) - The contents of the OCI API signing key. Overrides value provided by the `key_file`.
+  This cannot be used along with the `use_instance_principals` key.
 
 - `key_file` (string) - Full path and filename of the OCI API signing key. Overrides value provided
   by the [OCI config file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)


### PR DESCRIPTION
Hi, I would like to add the option to provide the OCI API Signing Key directly from the memory. This is already supported by the OCI Terraform provider and is useful when running Packer from CI. The key is not inteded to be checked into the source control, but rather dynamically fetched from a secrets manager system.

Additionally, small refactor and improvements of the surrounding comments and error messages were done.

